### PR TITLE
Drop hard-coded enum in `DigitalWalletProvider`

### DIFF
--- a/spec/definitions/DigitalWallet.yaml
+++ b/spec/definitions/DigitalWallet.yaml
@@ -7,15 +7,13 @@ allOf:
       - digitalWalletProvider
     properties:
       digitalWalletId:
-        description: Идентификатор
+        description: Идентификатор кошелька
         type: string
         minLength: 16
         maxLength: 256
         example: zu3TcwGI71Bpaaw2XkLWZXlhMdn4zpVzMQ
       digitalWalletProvider:
-        description: |
-          Идентификатор провайдера
+        description: Провайдер электронных денежных средств
         type: string
-        enum:
-          - webmoney
+        example: Paypal
 


### PR DESCRIPTION
Since we allow dynamically defined providers nowadays.

In line with valitydev/swag-wallets#7.